### PR TITLE
Port mode3 collision fix

### DIFF
--- a/src/planner/plan_env/include/plan_env/grid_map.h
+++ b/src/planner/plan_env/include/plan_env/grid_map.h
@@ -4,7 +4,13 @@
 #include <Eigen/Eigen>
 #include <Eigen/StdVector>
 #include <algorithm>
+// cv_bridge moved its headers to .hpp in Iron and dropped the .h form in
+// Jazzy; keep building on Humble as well.
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <cmath>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <iostream>

--- a/src/planner/plan_manage/config/planner.yaml
+++ b/src/planner/plan_manage/config/planner.yaml
@@ -5,7 +5,7 @@ scan_planner_node:
     fsm.navi_mode: 1
     fsm.thresh_replan: 1.0
     fsm.thresh_no_replan: 0.1
-    fsm.planning_horizon: 7.5
+    fsm.planning_horizon: 3.5
     fsm.emergency_time: 1.0
     fsm.fail_safe: true
     fsm.max_replan_fail_count: 1000
@@ -23,7 +23,7 @@ scan_planner_node:
     grid_map.double_cylinder_offset: 0.18
     grid_map.body_height: 0.4
     grid_map.obstacles_inflation_z_up: 0.1
-    grid_map.obstacles_inflation_z_down: 0.4
+    grid_map.obstacles_inflation_z_down: 0.1
     grid_map.frame_id: world
     grid_map.sliding_map_frame_id: sliding_map
     grid_map.ground_height: 0.0
@@ -55,7 +55,7 @@ scan_planner_node:
     manager.max_jerk: 4.0
     manager.control_points_distance: 0.2
     manager.feasibility_tolerance: 0.5
-    manager.planning_horizon: 7.5
+    manager.planning_horizon: 3.5
 
     optimization.lambda_smooth: 1.0
     optimization.lambda_collision: 1.0

--- a/src/planner/plan_manage/src/scan_replan_fsm.cpp
+++ b/src/planner/plan_manage/src/scan_replan_fsm.cpp
@@ -195,24 +195,28 @@ namespace scan_planner
 
   bool SCANReplanFSM::planGlobalTrajByWaypoints(const std::vector<Eigen::Vector3d> &waypoints)
   {
-    if (waypoints.empty())
+    if (waypoints.size() < 2)
     {
-      RCLCPP_WARN(node_->get_logger(), "No waypoint supplied for global trajectory");
+      RCLCPP_WARN(node_->get_logger(), "Reference path requires at least two points.");
       return false;
     }
 
     end_pt_ = waypoints.back();
+    std::vector<Eigen::Vector3d> reference_waypoints(waypoints.begin() + 1, waypoints.end());
 
     for (size_t i = 0; i < waypoints.size(); i++)
     {
       visualization_->displayGoalPoint(waypoints[i], Eigen::Vector4d(0, 0.5, 0.5, 1), 0.3, i);
     }
 
+    // Seed the global trajectory on the reference path itself rather than on the
+    // current odometry state; starting from the robot's pose and velocity is what
+    // pulled the trajectory into obstacles in reference-path mode.
     bool success = planner_manager_->planGlobalTrajWaypoints(
-        odom_pos_,
-        odom_vel_,
+        waypoints.front(),
         Eigen::Vector3d::Zero(),
-        waypoints,
+        Eigen::Vector3d::Zero(),
+        reference_waypoints,
         Eigen::Vector3d::Zero(),
         Eigen::Vector3d::Zero());
 
@@ -345,19 +349,44 @@ namespace scan_planner
       return;
     }
 
+    if (!have_odom_)
+    {
+      RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
+                           "No odometry yet, cannot plan global trajectory.");
+      return;
+    }
+
     trigger_ = true;
+    end_pt_ << msg->poses.back().pose.position.x,
+        msg->poses.back().pose.position.y,
+        msg->poses.back().pose.position.z + body_height_;
 
     std::vector<Eigen::Vector3d> waypoints;
     waypoints.reserve(msg->poses.size());
+    // Thin the path out: reference paths are usually sampled far more densely
+    // than the global trajectory needs.
+    constexpr double min_dist = 0.5;
+    Eigen::Vector3d last_wp;
+    bool first = true;
 
-    for (const auto& pose_stamped : msg->poses)
+    for (const auto &pose_stamped : msg->poses)
     {
       Eigen::Vector3d wp;
       wp(0) = pose_stamped.pose.position.x;
       wp(1) = pose_stamped.pose.position.y;
       wp(2) = pose_stamped.pose.position.z + body_height_; // Adjust for body height
-      waypoints.push_back(wp);
+
+      if (first || (wp - last_wp).norm() >= min_dist)
+      {
+        waypoints.push_back(wp);
+        last_wp = wp;
+        first = false;
+      }
     }
+
+    if ((waypoints.back() - end_pt_).norm() > 1e-6)
+      waypoints.push_back(end_pt_);
+
     bool success = planGlobalTrajByWaypoints(waypoints);
 
     if (success)
@@ -731,6 +760,30 @@ namespace scan_planner
 
     //cout << "info->velocity_traj_=" << info->velocity_traj_.get_control_points() << endl;
 
+    // In reference-path mode the global trajectory carries the supplied route, so
+    // it must not be regenerated from odometry to the goal. Re-seed from the
+    // trajectory itself and only redo the local rebound optimisation.
+    if (navi_mode_ == NAVI_MODE::REFERENCE_PATH)
+    {
+      start_pt_ = info->position_traj_.evaluateDeBoorT(t_cur);
+      start_vel_ = info->velocity_traj_.evaluateDeBoorT(t_cur);
+      start_acc_ = info->acceleration_traj_.evaluateDeBoorT(t_cur);
+
+      bool success = callReboundReplan(false, false);
+      if (!success)
+      {
+        success = callReboundReplan(true, false);
+        if (!success)
+        {
+          success = callReboundReplan(true, true);
+          if (!success)
+            return false;
+        }
+      }
+
+      return true;
+    }
+
     start_pt_ = odom_pos_;
     start_vel_ = info->velocity_traj_.evaluateDeBoorT(t_cur);
     start_acc_ = info->acceleration_traj_.evaluateDeBoorT(t_cur);
@@ -928,44 +981,47 @@ namespace scan_planner
 
   void SCANReplanFSM::getLocalTarget()
   {
-    double t;
+    const double max_vel = planner_manager_->pp_.max_vel_;
+    const double max_acc = planner_manager_->pp_.max_acc_;
+    const double duration = planner_manager_->global_data_.global_duration_;
+    double t_step = max_vel > 1e-6 ? planning_horizon_ / 20.0 / max_vel : 0.01;
+    t_step = std::max(t_step, 0.01);
 
-    double t_step = planning_horizon_ / 20 / planner_manager_->pp_.max_vel_;
-    double dist_min = 9999, dist_min_t = 0.0;
-    double target_t = planner_manager_->global_data_.global_duration_;
-    for (t = planner_manager_->global_data_.last_progress_time_; t < planner_manager_->global_data_.global_duration_; t += t_step)
+    // Project the start onto the global trajectory, then walk forward along it
+    // accumulating arc length until one planning horizon has been covered.
+    double t_proj = 0.0;
+    double min_dist_to_start = 9999.0;
+    for (double t = 0.0; t < duration; t += t_step)
     {
       Eigen::Vector3d pos_t = planner_manager_->global_data_.getPosition(t);
-      double dist = (pos_t - start_pt_).norm();
+      double dist_to_start = (pos_t - start_pt_).norm();
+      if (dist_to_start < min_dist_to_start)
+      {
+        min_dist_to_start = dist_to_start;
+        t_proj = t;
+      }
+    }
 
-      if (t < planner_manager_->global_data_.last_progress_time_ + 1e-5 && dist > planning_horizon_)
-      {
-        RCLCPP_ERROR(node_->get_logger(),
-                     "Local target progress mismatch: distance=%.3f horizon=%.3f progress_time=%.3f",
-                     dist, planning_horizon_, planner_manager_->global_data_.last_progress_time_);
-        local_target_pt_ = pos_t;
-        target_t = t;
-        planner_manager_->global_data_.last_progress_time_ = t;
-        break;
-      }
-      if (dist < dist_min)
-      {
-        dist_min = dist;
-        dist_min_t = t;
-      }
-      if (dist >= planning_horizon_)
-      {
-        local_target_pt_ = pos_t;
-        target_t = t;
-        planner_manager_->global_data_.last_progress_time_ = dist_min_t;
-        break;
-      }
-    }
-    if (t > planner_manager_->global_data_.global_duration_) // Last global point
+    double target_t = duration;
+    double total_dist = 0.0;
+    bool target_found = false;
+    Eigen::Vector3d prev_pos = planner_manager_->global_data_.getPosition(t_proj);
+    local_target_pt_ = end_pt_;
+
+    for (double t = t_proj; t < duration; t += t_step)
     {
-      local_target_pt_ = end_pt_;
-      target_t = planner_manager_->global_data_.global_duration_;
+      Eigen::Vector3d pos_t = planner_manager_->global_data_.getPosition(t);
+      total_dist += (pos_t - prev_pos).norm();
+      if (total_dist >= planning_horizon_)
+      {
+        local_target_pt_ = pos_t;
+        target_t = t;
+        target_found = true;
+        break;
+      }
+      prev_pos = pos_t;
     }
+    planner_manager_->global_data_.last_progress_time_ = target_found ? target_t : duration;
 
     auto targetOccupancy = [&](const Eigen::Vector3d &pt) {
       return planner_manager_->grid_map_->getInflateOccupancy(pt, estimateYawFromSegment(odom_pos_, pt));
@@ -992,7 +1048,7 @@ namespace scan_planner
         }
 
         double t_backward = target_t - dt;
-        if (t_backward >= std::max(0.0, dist_min_t))
+        if (t_backward >= std::max(0.0, t_proj))
         {
           Eigen::Vector3d pt = planner_manager_->global_data_.getPosition(t_backward);
           if (targetOccupancy(pt) == 0)
@@ -1018,7 +1074,7 @@ namespace scan_planner
       }
     }
 
-    if ((end_pt_ - local_target_pt_).norm() < (planner_manager_->pp_.max_vel_ * planner_manager_->pp_.max_vel_) / (2 * planner_manager_->pp_.max_acc_))
+    if ((end_pt_ - local_target_pt_).norm() < (max_vel * max_vel) / (2 * max_acc))
     {
       // local_target_vel_ = (end_pt_ - init_pt_).normalized() * planner_manager_->pp_.max_vel_ * (( end_pt_ - local_target_pt_ ).norm() / ((planner_manager_->pp_.max_vel_*planner_manager_->pp_.max_vel_)/(2*planner_manager_->pp_.max_acc_)));
       // cout << "A" << endl;
@@ -1027,6 +1083,8 @@ namespace scan_planner
     else
     {
       local_target_vel_ = planner_manager_->global_data_.getVelocity(target_t);
+      if (local_target_vel_.norm() > max_vel)
+        local_target_vel_ = local_target_vel_.normalized() * max_vel;
       // cout << "AA" << endl;
     }
   }

--- a/src/simulator/local_sensing/CMakeLists.txt
+++ b/src/simulator/local_sensing/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(Boost REQUIRED COMPONENTS filesystem iostreams program_options syst
 find_package(cv_bridge REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(glm REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(OpenMP REQUIRED)
@@ -40,6 +39,7 @@ target_link_libraries(pcl_render_node
 
 set(renderer_targets pcl_render_node)
 if(USE_GPU)
+  find_package(glm REQUIRED)   # only the OpenGL renderer uses glm
   find_package(GLEW REQUIRED)
   find_package(OpenGL REQUIRED)
   find_package(glfw3 REQUIRED)

--- a/src/simulator/local_sensing/src/opengl_render_node.cpp
+++ b/src/simulator/local_sensing/src/opengl_render_node.cpp
@@ -1,5 +1,10 @@
 #include "opengl_sim.hpp"
+// cv_bridge headers became .hpp in Iron; the .h form is gone in Jazzy.
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <algorithm>
 #include <cstdint>
 #include <chrono>

--- a/src/simulator/local_sensing/src/pointcloud_render_node.cpp
+++ b/src/simulator/local_sensing/src/pointcloud_render_node.cpp
@@ -30,7 +30,12 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <pcl/common/transforms.h>
+// cv_bridge headers became .hpp in Iron; the .h form is gone in Jazzy.
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/eigen.hpp>


### PR DESCRIPTION

## What this does

Two independent changes to the `ros2-community` branch:

1. **Ports `b654557 "fix: mode3 collision"` from upstream `main`.** This branch
   was created before that commit landed, so reference-path mode (`navi_mode:=3`)
   still has the behaviour the fix addresses. `e3f28a2 "fix: body height"` is
   already present here and needed no change.
2. **Makes the branch build on Jazzy** as well as Humble (`cv_bridge` headers and
   an unconditional `glm` dependency).

They are separate commits, happy to split into two PRs if you prefer.

## Commit 1 — port of the mode3 collision fix

All four changes are in `scan_replan_fsm.cpp`:

| Function | Change |
| --- | --- |
| `planGlobalTrajByWaypoints` | Seed the global trajectory from the reference path (`waypoints.front()`, zero velocity and acceleration) instead of the current odometry state; require at least two waypoints |
| `pathCallback` | Return early without odometry, set `end_pt_` explicitly from the last pose, thin waypoints to 0.5 m spacing, keep the end point |
| `planFromCurrentTraj` | In `REFERENCE_PATH` mode keep the global trajectory instead of regenerating it from odometry to the goal, re-seed from the trajectory at `t_cur`, and use the three-step rebound fallback |
| `getLocalTarget` | Project the start onto the global trajectory and advance by accumulated arc length, replacing the `last_progress_time_` logic; clamp the local target velocity to `max_vel` |

`planner.yaml` picks up the values that shipped with the same upstream commit:
`planning_horizon` 7.5 → 3.5 (both `fsm.` and `manager.`) and
`obstacles_inflation_z_down` 0.4 → 0.1.

The algorithm work is the upstream authors'; this only transposes it to rclcpp.

## Commit 2 — Jazzy build

- `cv_bridge` include guarded with `__has_include`, in `plan_env/grid_map.h`,
  `pointcloud_render_node.cpp` and `opengl_render_node.cpp`.
- `find_package(glm REQUIRED)` moved inside `if(USE_GPU)`. glm is only used by
  `shader_m.h` / `opengl_sim.hpp`, which only the OpenGL renderer includes;
  `pcl_render_node` neither includes nor links it, so the default CPU build was
  requiring a dependency it does not use.

## Testing

Built and run on **Ubuntu 22.04 / ROS 2 Humble** (this branch's target), and
additionally built on **Ubuntu 24.04 / ROS 2 Jazzy**.

- Full workspace builds on Humble: 13 packages, with `libglm-dev` *not* installed.
- Planner packages build on Jazzy.

Ran the bundled simulator (`run.launch.py`, mockamap + `pcl_render_node`):

**`navi_mode:=1`** — 2D Nav Goal to `(-10.0, 1.0)` from the default start
`(-19.0, 1.0)`: robot travelled 9.15 m and reached the goal, deviating laterally
(y 0.02 → 1.44) around obstacles.

**`navi_mode:=3`** — the path this PR touches. Published a straight reference
path of 61 poses at 0.25 m spacing (dense enough to exercise the new thinning)
along `y = 1.0`, 15 m across the obstacle field:

```
  t+ 5s  pos=(-16.67,  0.34)   trajectories=5
  t+10s  pos=(-14.20,  0.88)   trajectories=9
  t+15s  pos=(-11.18,  1.26)   trajectories=12
  t+20s  pos=( -8.08,  1.00)   trajectories=15
  t+25s  pos=( -5.13,  1.55)   trajectories=18
  t+30s  pos=( -4.09,  1.32)   trajectories=22

  22 bspline trajectories, 606 cmd_vel messages (564 non-zero)
  travelled 14.91 m, final position (-4.09, 1.32), target (-4.0, 1.0)
```

The robot follows the reference path while deviating between y = 0.34 and
y = 1.55 around obstacles, and replans continuously for the whole run.

**Not tested:** hardware, and the multi-floor keypoint mode (`navi_mode:=2`).

## Note on line endings

The sources mix CRLF and LF. Each line keeps the ending it already had, so the
diff shows only the changed hunks rather than the whole file.